### PR TITLE
Fix bugs, add license and implement features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,165 @@
-All Rights Reserved.
-This project is currently under a temporary placeholder license.
-License terms may change once approved by the server owner.
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ and therefore freely available.
 
 ## Documentation
 If you do not know how to use this mod, there's a basic documentation over [here](./docs/documentation.md) that should cover you.
+
+## License & Attribution
+
+This project is licensed under the **LGPL-3.0 License** - see the [LICENSE](./LICENSE) file for details.
+
+### For Developers (Code Usage)
+If you use parts of this project (code, logic, or assets) in your own mod, please include the following in your README or "About" section:
+
+> **TabManager** by **SnackBag Studios** (https://studios.snackbag.net/)
+> - **Original Source:** https://github.com/snackbag/TabManager/
+> - **Original Author:** Tobiazsh (https://github.com/tobiazsh)
+> - **Licensed under:** LGPL-3.0
+>
+> *Portions of this mod use code from TabManager.*
+
+### For Modpack Creators
+You are free to include this mod in any modpack! While not strictly required by the license to list every mod on your main page, we appreciate a link back to our project:
+
+> **TabManager** by **SnackBag Studios** ([Modrinth/GitHub Link])

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ repositories {
 loom {
 	splitEnvironmentSourceSets()
 
-	accessWidenerPath = file("src/main/resources/tabmanager.classtweaker")
-
 	mods {
 		"tabmanager" {
 			sourceSet sourceSets.main

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ repositories {
 loom {
 	splitEnvironmentSourceSets()
 
+	accessWidenerPath = file("src/main/resources/tabmanager.classtweaker")
+
 	mods {
 		"tabmanager" {
 			sourceSet sourceSets.main

--- a/src/client/java/net/snackbag/tabmanager/TabManagerClient.java
+++ b/src/client/java/net/snackbag/tabmanager/TabManagerClient.java
@@ -36,7 +36,8 @@ public class TabManagerClient implements ClientModInitializer {
         try {
             Config.loadConfigFile(ConfigDirectory.getConfigFile());
         } catch (IOException e) {
-            TabManagerClient.LOGGER.error("Failed to load config file!", e);
+            TabManagerClient.LOGGER.error("Failed to load config file! Maybe it doesn't exist it. Using empty config!", e);
+            Config.INSTANCE = new Config();
         }
     }
 }

--- a/src/client/java/net/snackbag/tabmanager/access/ButtonWidgetAccessor.java
+++ b/src/client/java/net/snackbag/tabmanager/access/ButtonWidgetAccessor.java
@@ -1,0 +1,7 @@
+package net.snackbag.tabmanager.access;
+
+import net.minecraft.client.gui.widget.ButtonWidget;
+
+public interface ButtonWidgetAccessor {
+    void tabmanager$setOnPress(ButtonWidget.PressAction onPress);
+}

--- a/src/client/java/net/snackbag/tabmanager/access/CreativeInventoryScreenAccessor.java
+++ b/src/client/java/net/snackbag/tabmanager/access/CreativeInventoryScreenAccessor.java
@@ -1,0 +1,5 @@
+package net.snackbag.tabmanager.access;
+
+public interface CreativeInventoryScreenAccessor {
+    void tabmanager$setCurrentPage(int page);
+}

--- a/src/client/java/net/snackbag/tabmanager/command/TabCommand.java
+++ b/src/client/java/net/snackbag/tabmanager/command/TabCommand.java
@@ -239,6 +239,9 @@ public class TabCommand {
 
         // Compile the pattern from the raw filter (without the prefix)
         ItemFilter itemFilter = ItemFilter.parse(predicateSource);
+
+        if (itemFilter == null) return Command.SINGLE_SUCCESS; // Error message already printed in ItemFilter.parse() - regex compilation failed
+
         itemFilter.addApplicableGroup(targetGroup);
         Config.INSTANCE.filters.add(itemFilter);
         Config.reload();

--- a/src/client/java/net/snackbag/tabmanager/config/Config.java
+++ b/src/client/java/net/snackbag/tabmanager/config/Config.java
@@ -1,8 +1,6 @@
 package net.snackbag.tabmanager.config;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemGroups;
 import net.snackbag.tabmanager.exception.ConfigParseException;
@@ -121,7 +119,8 @@ public class Config {
      */
     public static void writeConfigFile(File configFile) throws IOException {
         try (FileOutputStream fos = new FileOutputStream(configFile)) {
-            String parsedConfig = Config.INSTANCE.serialize().toString();
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            String parsedConfig = gson.toJson(Config.INSTANCE.serialize());
             byte[] parsedConfigBytes = parsedConfig.getBytes();
             fos.write(parsedConfigBytes);
         }

--- a/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
+++ b/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
@@ -8,6 +8,18 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.function.Consumer;
 
+/*
+ * ╔═══════════════════════════════════════════════════════════════════════════════════════╗
+ * ║ File Dialog Logic for TabManager                                                      ║
+ * ║ Code taken from Tobiazsh's Mod "MyWorld Traffic Addition", licensed under LGPL-3.0    ║
+ * ║ https://github.com/snackbag/TabManager                                                ║
+ * ║ https://github.com/tobiazsh/MyWorld-Traffic-Addition                                  ║
+ * ║                                                                                       ║
+ * ║ Licensed under LGPL-3.0. Build something cool, but keep it open!                      ║
+ * ╚═══════════════════════════════════════════════════════════════════════════════════════╝
+ */
+
+
 /**
  * Utility class for native file dialogs using TinyFD.
  */

--- a/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
+++ b/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
@@ -9,14 +9,14 @@ import java.nio.LongBuffer;
 import java.util.function.Consumer;
 
 /*
- * ╔═══════════════════════════════════════════════════════════════════════════════════════╗
- * ║ File Dialog Logic for TabManager                                                      ║
- * ║ Code taken from Tobiazsh's Mod "MyWorld Traffic Addition", licensed under LGPL-3.0    ║
- * ║ https://github.com/snackbag/TabManager                                                ║
- * ║ https://github.com/tobiazsh/MyWorld-Traffic-Addition                                  ║
- * ║                                                                                       ║
- * ║ Licensed under LGPL-3.0. Build something cool, but keep it open!                      ║
- * ╚═══════════════════════════════════════════════════════════════════════════════════════╝
+ * ╔═════════════════════════════════════════════════════════════════════════════════════════════════════╗
+ * ║ File Dialog Logic for TabManager                                                                    ║
+ * ║ Code taken from Tobiazsh's Mod "MyWorld Traffic Addition" version 1.7.0, licensed under LGPL-3.0    ║
+ * ║ https://github.com/snackbag/TabManager                                                              ║
+ * ║ https://github.com/tobiazsh/MyWorld-Traffic-Addition                                                ║
+ * ║                                                                                                     ║
+ * ║ Licensed under LGPL-3.0. Build something cool, but keep it open!                                    ║
+ * ╚═════════════════════════════════════════════════════════════════════════════════════════════════════╝
  */
 
 

--- a/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
+++ b/src/client/java/net/snackbag/tabmanager/file_dialog/NativeFileDialogs.java
@@ -8,8 +8,9 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.function.Consumer;
 
-// Straight up stole from my mod MyWorld Traffic Addition lmao
-// I do not care about the duplicates btw because it's simple enough and would be kind of dangerous with the memory management
+/**
+ * Utility class for native file dialogs using TinyFD.
+ */
 public class NativeFileDialogs {
 
     /**

--- a/src/client/java/net/snackbag/tabmanager/filesystem/ConfigDirectory.java
+++ b/src/client/java/net/snackbag/tabmanager/filesystem/ConfigDirectory.java
@@ -90,7 +90,7 @@ public class ConfigDirectory {
 
         try (
                 FileInputStream fileInputStream = new FileInputStream(getConfigFile());
-                FileOutputStream fileOutputStream = new FileOutputStream(MOD_CONFIG_FILE);
+                FileOutputStream fileOutputStream = new FileOutputStream(getBakConfigFile());
         ) {
             byte[] fileContent = fileInputStream.readAllBytes();
             if (fileContent.length == 0) return; // Do nothing if config is empty

--- a/src/client/java/net/snackbag/tabmanager/filesystem/ConfigDirectory.java
+++ b/src/client/java/net/snackbag/tabmanager/filesystem/ConfigDirectory.java
@@ -47,8 +47,7 @@ public class ConfigDirectory {
             try {
                 if (configFile.toFile().createNewFile())
                     TabManagerClient.LOGGER.info("Created new config file at {}", configFile.toAbsolutePath());
-                else
-                    TabManagerClient.LOGGER.error("File already exists at {}", configFile.toAbsolutePath());
+                // No else needed, as it would already exist if we are in this block
             } catch (Exception e) {
                 TabManagerClient.LOGGER.error("Failed to create config file: {}", e.getMessage());
                 return false;
@@ -68,8 +67,7 @@ public class ConfigDirectory {
             try {
                 if (bakConfigFile.createNewFile())
                     TabManagerClient.LOGGER.info("Created new bak config file at {}", bakConfigFile.toPath());
-                else
-                    TabManagerClient.LOGGER.error("File already exists at {}", bakConfigFile.toPath());
+                // No else needed, as it would already exist if we are in this block
             } catch (IOException e) {
                 TabManagerClient.LOGGER.error("Failed to create bak config file: {}", e.getMessage());
                 return false;

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/ButtonWidgetMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/ButtonWidgetMixin.java
@@ -1,0 +1,17 @@
+package net.snackbag.tabmanager.mixin.client;
+
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.snackbag.tabmanager.access.ButtonWidgetAccessor;
+import org.spongepowered.asm.mixin.*;
+
+@Mixin(ButtonWidget.class)
+public abstract class ButtonWidgetMixin implements ButtonWidgetAccessor {
+
+    @Shadow @Final @Mutable
+    protected ButtonWidget.PressAction onPress;
+
+    @Override
+    public void tabmanager$setOnPress(ButtonWidget.PressAction onPress) {
+        this.onPress = onPress;
+    }
+}

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/FabricItemGroupButtonWidgetMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/FabricItemGroupButtonWidgetMixin.java
@@ -20,6 +20,10 @@ public class FabricItemGroupButtonWidgetMixin {
     private void tabmanager$onInit(int x, int y, FabricCreativeGuiComponents.Type type, CreativeInventoryScreen screen, CallbackInfo ci) {
         ((ButtonWidgetAccessor) this).tabmanager$setOnPress((bw) -> {
             int toPage = type == FabricCreativeGuiComponents.Type.NEXT ? screen.getCurrentPage() + 1 : screen.getCurrentPage() - 1;
+            
+            if (toPage < 0 || toPage >= screen.getPageCount()) // >= because getPageCount is 1-based and toPage is 0-based
+                return;
+
             ((CreativeInventoryScreenAccessor) screen).tabmanager$setCurrentPage(toPage);
         });
     }

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/FabricItemGroupButtonWidgetMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/FabricItemGroupButtonWidgetMixin.java
@@ -1,0 +1,27 @@
+package net.snackbag.tabmanager.mixin.client;
+
+import net.fabricmc.fabric.impl.client.itemgroup.FabricCreativeGuiComponents;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.snackbag.tabmanager.access.ButtonWidgetAccessor;
+import net.snackbag.tabmanager.access.CreativeInventoryScreenAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@SuppressWarnings("UnstableApiUsage")
+@Mixin(FabricCreativeGuiComponents.ItemGroupButtonWidget.class)
+public class FabricItemGroupButtonWidgetMixin {
+
+    @Inject(
+            method = "<init>",
+            at = @At("TAIL")
+    )
+    private void tabmanager$onInit(int x, int y, FabricCreativeGuiComponents.Type type, CreativeInventoryScreen screen, CallbackInfo ci) {
+        ((ButtonWidgetAccessor) this).tabmanager$setOnPress((bw) -> {
+            int toPage = type == FabricCreativeGuiComponents.Type.NEXT ? screen.getCurrentPage() + 1 : screen.getCurrentPage() - 1;
+            ((CreativeInventoryScreenAccessor) screen).tabmanager$setCurrentPage(toPage);
+        });
+    }
+
+}

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/ItemGroupButtonWidgetMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/ItemGroupButtonWidgetMixin.java
@@ -12,6 +12,9 @@ import static net.snackbag.tabmanager.util.CreativeMenuUtility.getPageCount;
 @Mixin(FabricCreativeGuiComponents.ItemGroupButtonWidget.class)
 abstract public class ItemGroupButtonWidgetMixin {
 
+    /**
+     * Allows the buttons to be displayed on fake pages.
+     */
     @Redirect(
             method = "renderWidget",
             at = @At(

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/ItemGroupMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/ItemGroupMixin.java
@@ -72,7 +72,8 @@ abstract public class ItemGroupMixin implements ItemGroupAccessor {
     @Inject(method = "updateEntries", at = @At("TAIL"))
     private void updateEntries(ItemGroup.DisplayContext displayContext, CallbackInfo ci) {
         // Apply filters after update here
-        Config.reload();
+        this.tabmanager$displayStacks = new CopyOnWriteArrayList<>(this.displayStacks); // Reset to all items first
+        Config.reload(); // Then re-apply filters (reload the entire config)
     }
 
     /**
@@ -127,8 +128,6 @@ abstract public class ItemGroupMixin implements ItemGroupAccessor {
     @Override
     public void tabmanager$applyFilterDisplayItems(ItemFilter filter) {
         if (!filter.getApplicableGroups().contains((ItemGroup)(Object)this)) return;
-        tabmanager$displayStacks = new CopyOnWriteArrayList<>();
-        tabmanager$displayStacks.addAll(this.displayStacks);
         for (ItemStack istack : this.tabmanager$displayStacks) {
             if (!tabmanager$displayStacks.contains(istack)) continue; // Avoid removing non-existent
             String itemId = istack.getItem().toString();

--- a/src/client/java/net/snackbag/tabmanager/mixin/client/MixinCreativeInventoryScreenMixin.java
+++ b/src/client/java/net/snackbag/tabmanager/mixin/client/MixinCreativeInventoryScreenMixin.java
@@ -1,0 +1,21 @@
+package net.snackbag.tabmanager.mixin.client;
+
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.snackbag.tabmanager.access.CreativeInventoryScreenAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+@SuppressWarnings({"MixinAnnotationTarget"})
+@Mixin(value = CreativeInventoryScreen.class, priority = 1500)
+public abstract class MixinCreativeInventoryScreenMixin implements CreativeInventoryScreenAccessor {
+
+    @Shadow(remap = false) // FAPI
+    private static int currentPage;
+
+    @Override
+    public void tabmanager$setCurrentPage(int page) {
+        currentPage = page;
+    }
+
+}

--- a/src/client/java/net/snackbag/tabmanager/ui/component/FilterEditComponent.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/component/FilterEditComponent.java
@@ -116,9 +116,9 @@ public class FilterEditComponent extends OverlayContainer<FlowLayout> {
         this.filter = filter;
         this.isNew = isNew;
 
-        if (isNew || filter == null) {
-            predicateInput.setText("");
-        } else {
+        resetComponents();
+
+        if (!isNew && filter != null) {
             String source = filter.getPredicateSource();
             predicateInput.setEditable(false);
             predicateInput.write(source.substring(source.indexOf(":") + 1));
@@ -195,6 +195,7 @@ public class FilterEditComponent extends OverlayContainer<FlowLayout> {
 
     public void close() {
         hide();
+        resetComponents();
     }
 
     public ItemFilter getFilter() {
@@ -212,6 +213,15 @@ public class FilterEditComponent extends OverlayContainer<FlowLayout> {
 
     public boolean isNew() {
         return isNew;
+    }
+
+    public void resetComponents() {
+        predicateInput.setText("");
+        predicateInput.setEditable(true);
+        isRegexCheckbox.checked(false);
+        appliedGroups.clear();
+        availableGroups = new ArrayList<>(itemGroups);
+        updateGroups();
     }
 
 }

--- a/src/client/java/net/snackbag/tabmanager/ui/component/FilterEditComponent.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/component/FilterEditComponent.java
@@ -198,11 +198,14 @@ public class FilterEditComponent extends OverlayContainer<FlowLayout> {
         resetComponents();
     }
 
-    public ItemFilter getFilter() {
+    public @Nullable ItemFilter getFilter() {
         if (isNew()) {
             // If new, return a new filter with all the traits set
             String predicateSource = (isRegexCheckbox.isChecked() ? "regex:" : "glob:") + predicateInput.getText();
             ItemFilter newFilter = ItemFilter.parse(predicateSource);
+
+            if (newFilter == null) return null; // Parsing failed
+
             appliedGroups.forEach(newFilter::addApplicableGroup);
             return newFilter;
         } else {

--- a/src/client/java/net/snackbag/tabmanager/ui/component/InventoryEditComponent.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/component/InventoryEditComponent.java
@@ -219,18 +219,21 @@ public class InventoryEditComponent {
     }
 
     private void nextPage() {
-        if (currentPage >= maxPages) return; // Cannot go more than maxPages
-
-        currentPage++;
-        updatePageLabel();
-        updateItemGroups();
-        updateButtons();
+        toPage(currentPage + 1);
     }
 
     private void previousPage() {
-        if (currentPage <= 1) return; // Cannot go less than page 1
+        toPage(currentPage - 1);
+    }
 
-        currentPage--;
+    /**
+     * Moves to the specified page
+     * @param page The page to move to (1-indexed)
+     */
+    private void toPage(int page) {
+        if (page < 1 || page > maxPages) return; // Out of bounds
+
+        currentPage = page; // Pages are 1-indexed for the user
         updatePageLabel();
         updateItemGroups();
         updateButtons();
@@ -351,6 +354,19 @@ public class InventoryEditComponent {
         components.forEach(component::removeChild);
     }
 
+    /**
+     * Checks if user's current page is within bounds after changes and corrects it to the nearest valid page if not
+     */
+    private void checkPageBounds() {
+        if (this.currentPage > this.maxPages) {
+            toPage(maxPages);
+        }
+
+        if (this.currentPage < 1) {
+            toPage(1);
+        }
+    }
+
 
 
     // LOGIC FOR BUTTON ACTIONS --------------------------------------
@@ -400,6 +416,7 @@ public class InventoryEditComponent {
 
         updatePageCount();
         updateItemGroups();
+        checkPageBounds();
     }
 
     /**

--- a/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
@@ -154,11 +154,13 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
     private void exportConfig() {
         fileIOExecutor.submit(() -> {
             AtomicBoolean aborted = new AtomicBoolean(false);
-            String savePath = NativeFileDialogs.save(Text.translatable("tabmanager.gui.edit_screen.export_config_button").toString(), new NativeFileDialogs.FilterItem(
-                    "Tab Manager Config Files",
-                    new String[] {"*.json", "*.tmconfig"}),
+            String savePath = NativeFileDialogs.save(
+                    Text.translatable("tabmanager.gui.edit_screen.export_config_button").toString(),
+                    new NativeFileDialogs.FilterItem(
+                        "Tab Manager Config Files",
+                        new String[] {"*.json", "*.tmconfig"}),
                     ConfigDirectory.getConfigDirectory().toAbsolutePath().toString(),
-                     "config.tmconfig",
+                    "config.tmconfig",
                     (msg) -> aborted.set(true));
 
             if (aborted.get()) return;
@@ -178,9 +180,11 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
     private void importConfig() {
         fileIOExecutor.submit(() -> {
             AtomicBoolean aborted = new AtomicBoolean(false);
-            String loadPath = NativeFileDialogs.open(Text.translatable("tabmanager.gui.edit_screen.import_config_button").toString(), new NativeFileDialogs.FilterItem(
-                    "Tab Manager Config Files",
-                    new String[] {"*.json", "*.tmconfig"}),
+            String loadPath = NativeFileDialogs.open(
+                    Text.translatable("tabmanager.gui.edit_screen.import_config_button").toString(),
+                    new NativeFileDialogs.FilterItem(
+                        "Tab Manager Config Files",
+                        new String[] {"*.json", "*.tmconfig"}),
                     ConfigDirectory.getConfigDirectory().toAbsolutePath().toString(),
                     (msg) -> aborted.set(true));
 

--- a/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
@@ -5,6 +5,10 @@ import io.wispforest.owo.ui.component.ButtonComponent;
 import io.wispforest.owo.ui.component.Components;
 import io.wispforest.owo.ui.container.*;
 import io.wispforest.owo.ui.core.*;
+import io.wispforest.owo.ui.util.UIErrorToast;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.toast.SystemToast;
+import net.minecraft.client.toast.ToastManager;
 import net.minecraft.text.Text;
 import net.snackbag.tabmanager.TabManagerClient;
 import net.snackbag.tabmanager.config.Config;
@@ -14,7 +18,10 @@ import net.snackbag.tabmanager.ui.component.FilterEditComponent;
 import net.snackbag.tabmanager.ui.component.FilterListComponent;
 import net.snackbag.tabmanager.ui.component.IconSelectorComponent;
 import net.snackbag.tabmanager.ui.component.InventoryEditComponent;
+import net.snackbag.tabmanager.ui.toast.ZToast;
+import net.snackbag.tabmanager.util.ItemFilter;
 import net.snackbag.tabmanager.util.ItemGroupUtility;
+import net.snackbag.tabmanager.util.ToastUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -27,6 +34,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class EditScreen extends BaseOwoScreen<FlowLayout> {
 
     protected InventoryEditComponent inventoryEditComponent;
+    protected FilterEditComponent filterEditComponent;
+    protected FilterListComponent filterListComponent;
 
     ExecutorService fileIOExecutor = Executors.newCachedThreadPool();
 
@@ -56,29 +65,14 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
         iconSelectorComponent.zIndex(1000);
 
         // References to allow mutual access between components
-        AtomicReference<FilterEditComponent> filterEditRef = new AtomicReference<>();
-        AtomicReference<FilterListComponent> filterListRef = new AtomicReference<>();
-
-        FilterEditComponent filterEditComponent = new FilterEditComponent(
+        filterEditComponent = new FilterEditComponent(
                 Component::remove, // on hide
                 rootComponent::child, // on show
-                (comp) -> { // on save
-                    if (comp.isNew()) { // IF is new, add to config and update
-                        Config.INSTANCE.filters.add(comp.getFilter());
-                        Config.reload();
-                    } else { // ... otherwise just update
-                        Config.reload();
-                    }
-
-                    comp.close();
-
-                    filterListRef.get().refresh(); // Refresh the filter list to show changes
-                }
+                this::onFilterSave // on save
         );
-        filterEditRef.set(filterEditComponent);
         filterEditComponent.zIndex(2000);
 
-        FilterListComponent filterListComponent = new FilterListComponent(
+        filterListComponent = new FilterListComponent(
                 Component::remove, // on hide
                 rootComponent::child,  // on show
                 (filter, isNew) -> { // on edit and add
@@ -86,9 +80,8 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
                     filterEditComponent.show();
                 }
         );
-        filterListRef.set(filterListComponent);
-
         filterListComponent.zIndex(1000);
+
         inventoryEditComponent = new InventoryEditComponent(
                 195, 127,
                 (btn, tab) -> { // Item Filter Click
@@ -200,6 +193,38 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    /**
+     * Called when a filter is saved from the FilterEditComponent
+     */
+    private void onFilterSave(FilterEditComponent comp) {
+        if (comp.isNew()) { // IF is new, add to config and update
+            ItemFilter filter = comp.getFilter();
+
+            if (filter != null) {
+                Config.INSTANCE.filters.add(comp.getFilter());
+                Config.reload();
+            } else {
+
+                // Show system toast on error
+                ToastUtil.displayToast(
+                        MinecraftClient.getInstance(),
+                        ZToast.ZToastType.WARNING,
+                        Text.translatable("tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_title"),
+                        Text.translatable("tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_description"),
+                        500f // Very high Z to ensure visibility
+                );
+
+                TabManagerClient.LOGGER.error("Failed to compile ItemFilter");
+            }
+        } else { // ... otherwise just update
+            Config.reload();
+        }
+
+        comp.close();
+
+        filterListComponent.refresh(); // Refresh the filter list to show changes
     }
 
     @Override

--- a/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
@@ -235,8 +235,12 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
 
         // Save config on screen exit
         try {
+            ItemGroupUtility.saveItemGroupsToConfig();
+
             ConfigDirectory.backupConfigFile();
             Config.writeConfigFile(ConfigDirectory.getConfigFile());
+
+            // Refresh inventory to apply any changes made
             inventoryEditComponent.refresh();
             Config.reload();
             ItemGroupUtility.reloadItemGroups();

--- a/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/screen/EditScreen.java
@@ -37,8 +37,6 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
     protected FilterEditComponent filterEditComponent;
     protected FilterListComponent filterListComponent;
 
-    ExecutorService fileIOExecutor = Executors.newCachedThreadPool();
-
     @Override
     protected @NotNull OwoUIAdapter<FlowLayout> createAdapter() {
         return OwoUIAdapter.create(this, Containers::verticalFlow);
@@ -152,10 +150,10 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
      * Uses TinyFD to export the current config to a chosen location in a separate thread
      */
     private void exportConfig() {
-        fileIOExecutor.submit(() -> {
+        MinecraftClient.getInstance().execute(() -> {
             AtomicBoolean aborted = new AtomicBoolean(false);
             String savePath = NativeFileDialogs.save(
-                    Text.translatable("tabmanager.gui.edit_screen.export_config_button").toString(),
+                    Text.translatable("tabmanager.gui.edit_screen.export_config_button").getString(),
                     new NativeFileDialogs.FilterItem(
                         "Tab Manager Config Files",
                         new String[] {"*.json", "*.tmconfig"}),
@@ -178,10 +176,10 @@ public class EditScreen extends BaseOwoScreen<FlowLayout> {
      * Uses TinyFD to import a config from a chosen location in a separate thread
      */
     private void importConfig() {
-        fileIOExecutor.submit(() -> {
+        MinecraftClient.getInstance().execute(() -> {
             AtomicBoolean aborted = new AtomicBoolean(false);
             String loadPath = NativeFileDialogs.open(
-                    Text.translatable("tabmanager.gui.edit_screen.import_config_button").toString(),
+                    Text.translatable("tabmanager.gui.edit_screen.import_config_button").getString(),
                     new NativeFileDialogs.FilterItem(
                         "Tab Manager Config Files",
                         new String[] {"*.json", "*.tmconfig"}),

--- a/src/client/java/net/snackbag/tabmanager/ui/toast/ZToast.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/toast/ZToast.java
@@ -1,0 +1,55 @@
+package net.snackbag.tabmanager.ui.toast;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.toast.SystemToast;
+import net.minecraft.client.toast.ToastManager;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Class that wraps {@link net.minecraft.client.toast.SystemToast} to provide a way of setting the Z index of such toast and provides general-purpose Toast Types.
+ */
+public class ZToast extends SystemToast {
+
+    public final float z;
+
+    public ZToast(Type type, Text title, @Nullable Text description, float z) {
+        super(type, title, description);
+        this.z = z;
+    }
+
+    @Override
+    public Visibility draw(DrawContext context, ToastManager manager, long startTime) {
+        context.push();
+        context.translate(0, 0, this.z);
+        Visibility visibility = super.draw(context, manager, startTime);
+        context.pop();
+        return visibility;
+    }
+
+    public static void show(
+            @NotNull ToastManager manager,
+            ZToastType type,
+            Text title,
+            Text description,
+            float z
+    ) {
+        manager.add(new ZToast(type, title, description, z));
+    }
+
+    public static class ZToastType extends SystemToast.Type {
+        public ZToastType(long duration) {
+            super(duration);
+        }
+
+        public ZToastType() {
+            super();
+        }
+
+        public static final ZToast.ZToastType INFO = new ZToastType();
+        public static final ZToast.ZToastType WARNING = new ZToastType();
+        public static final ZToast.ZToastType ERROR = new ZToastType();
+    }
+}

--- a/src/client/java/net/snackbag/tabmanager/ui/toast/ZToast.java
+++ b/src/client/java/net/snackbag/tabmanager/ui/toast/ZToast.java
@@ -1,6 +1,5 @@
 package net.snackbag.tabmanager.ui.toast;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.toast.SystemToast;
 import net.minecraft.client.toast.ToastManager;

--- a/src/client/java/net/snackbag/tabmanager/util/ItemFilter.java
+++ b/src/client/java/net/snackbag/tabmanager/util/ItemFilter.java
@@ -1,8 +1,10 @@
 package net.snackbag.tabmanager.util;
 
+import blue.endless.jankson.annotation.Nullable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemGroup;
+import net.snackbag.tabmanager.TabManagerClient;
 import net.snackbag.tabmanager.access.ItemGroupAccessor;
 import net.snackbag.tabmanager.exception.ItemFilterParseException;
 
@@ -10,6 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Class for filtering OUT items
@@ -60,15 +63,20 @@ public class ItemFilter {
     /**
      * Parses either a glob or a regex into an ItemFilter
      * @param line the glob or regex mask
-     * @return the ItemFilter without any applicable {@link ItemGroup}s. Must manually apply later.
+     * @return the ItemFilter without any applicable {@link ItemGroup}s. Must manually apply later. Can be null if parsing failed.
      */
-    public static ItemFilter parse(String line) {
+    public static @Nullable ItemFilter parse(String line) {
         line = line.trim();
 
         if (line.startsWith("regex:")) {
             String regex = line.substring("regex:".length());
-            Pattern pattern = RegexCompiler.compileRegex(regex);
-            return new ItemFilter(id -> pattern.matcher(id).matches(), line);
+            try {
+                Pattern pattern = RegexCompiler.compileRegex(regex);
+                return new ItemFilter(id -> pattern.matcher(id).matches(), line);
+            } catch (PatternSyntaxException e) {
+                TabManagerClient.LOGGER.warn("Invalid regular expression in ItemFilter: {}! Will not compile...", regex, e);
+                return null;
+            }
         }
 
         if (line.startsWith("glob:")) {
@@ -85,10 +93,10 @@ public class ItemFilter {
     /**
      * Produces an ItemFilter from an {@link JsonObject}
      * @param filterObj The {@link JsonObject} to parse the ItemFilter from
-     * @return The parsed ItemFilter
+     * @return The parsed ItemFilter or null if parsing failed
      * @see ItemFilter#serialize()
      */
-    public static ItemFilter parse(JsonObject filterObj) throws ItemFilterParseException {
+    public static @Nullable ItemFilter parse(JsonObject filterObj) throws ItemFilterParseException {
 
         // Checks
         if (!filterObj.has("serializeVersion"))
@@ -113,7 +121,9 @@ public class ItemFilter {
         groupsArray.forEach(itemGroup -> applicableGroups.add(ItemGroupUtility.parse(itemGroup.getAsString())));
 
         ItemFilter filter = ItemFilter.parse(predicateSource);
-        filter.setApplicableGroups(applicableGroups);
+
+        if (filter != null)
+            filter.setApplicableGroups(applicableGroups);
 
         return filter;
     }

--- a/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
+++ b/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
@@ -19,8 +19,14 @@ public class ItemGroupUtility {
     public static List<VanillaSnapshot> VANILLA_GROUPS = null;
 
     /**
-     * @param iconId null wenn Default
-     */
+     * A snapshot of a vanilla ItemGroup's properties
+     * @param id The id of the ItemGroup
+     * @param page The page of the ItemGroup
+     * @param column The column of the ItemGroup
+     * @param rowOrdinal The row ordinal of the ItemGroup
+     * @param hidden Whether the ItemGroup is hidden
+     * @param iconId The icon id of the ItemGroup
+     **/
     public record VanillaSnapshot(String id, int page, int column, int rowOrdinal, boolean hidden, Identifier iconId) { }
 
     /**

--- a/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
+++ b/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
@@ -1,5 +1,6 @@
 package net.snackbag.tabmanager.util;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.item.*;
 import net.minecraft.registry.Registries;
@@ -100,6 +101,21 @@ public class ItemGroupUtility {
                     .collect(Collectors.toCollection(ArrayList::new));
         }
         Config.INSTANCE.itemGroups.forEach(igroup -> ItemGroupUtility.applySerialized(igroup.getAsJsonObject()));
+    }
+
+    /**
+     * Saves all ItemGroups to the config
+     */
+    public static void saveItemGroupsToConfig() {
+        if (Config.INSTANCE == null) return;
+
+        JsonArray arr = new JsonArray();
+        ItemGroups.getGroups()
+                .stream()
+                .filter(igroup -> !igroup.isSpecial())
+                .forEach(igroup -> arr.add(serialize(igroup)));
+
+        Config.INSTANCE.itemGroups = arr;
     }
 
     /**

--- a/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
+++ b/src/client/java/net/snackbag/tabmanager/util/ItemGroupUtility.java
@@ -16,6 +16,7 @@ public class ItemGroupUtility {
 
     public static final int SERIALIZE_VERSION = 1;
 
+    // Snapshot of all vanilla ItemGroups for resetting purposes
     public static List<VanillaSnapshot> VANILLA_GROUPS = null;
 
     /**
@@ -43,12 +44,18 @@ public class ItemGroupUtility {
                 .orElse(null);
     }
 
+    /**
+     * Populates all ItemGroups with their respective tab keys
+     */
     public static void populateItemGroups() {
         List<ItemGroup> allGroups = ItemGroups.getGroups();
 
         allGroups.forEach(igroup -> ((ItemGroupAccessor)igroup).tabmanager$setTabKey(Registries.ITEM_GROUP.getId(igroup)));
     }
 
+    /**
+     * Applies all filters from the config to all ItemGroups
+     */
     public static void applyFilters() {
         List<ItemGroup> allGroups = ItemGroups.getGroups();
 
@@ -63,6 +70,9 @@ public class ItemGroupUtility {
         });
     }
 
+    /**
+     * Reloads all ItemGroups from the config
+     */
     public static void reloadItemGroups() {
         if (VANILLA_GROUPS == null) { // First time initialization; snapshot current vanilla state
             VANILLA_GROUPS = ItemGroups.getGroups()
@@ -92,6 +102,9 @@ public class ItemGroupUtility {
         Config.INSTANCE.itemGroups.forEach(igroup -> ItemGroupUtility.applySerialized(igroup.getAsJsonObject()));
     }
 
+    /**
+     * Resets all ItemGroups to their vanilla state
+     */
     public static void resetItemGroups() {
         if (VANILLA_GROUPS == null) return;
 
@@ -117,6 +130,11 @@ public class ItemGroupUtility {
         });
     }
 
+    /**
+     * Serializes an ItemGroup into a JsonObject
+     * @param group the ItemGroup to serialize
+     * @return the serialized JsonObject
+     */
     public static JsonObject serialize(ItemGroup group) {
         JsonObject serialized = new JsonObject();
 

--- a/src/client/java/net/snackbag/tabmanager/util/RegexCompiler.java
+++ b/src/client/java/net/snackbag/tabmanager/util/RegexCompiler.java
@@ -1,6 +1,7 @@
 package net.snackbag.tabmanager.util;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class RegexCompiler {
 
@@ -27,7 +28,7 @@ public class RegexCompiler {
      * @param pattern The regex pattern in form of a string
      * @return The regular expression {@link Pattern}
      */
-    public static Pattern compileRegex(String pattern) {
+    public static Pattern compileRegex(String pattern) throws PatternSyntaxException {
         return Pattern.compile(pattern);
     }
 

--- a/src/client/java/net/snackbag/tabmanager/util/ToastUtil.java
+++ b/src/client/java/net/snackbag/tabmanager/util/ToastUtil.java
@@ -1,0 +1,19 @@
+package net.snackbag.tabmanager.util;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
+import net.snackbag.tabmanager.ui.toast.ZToast;
+
+public class ToastUtil {
+
+    public static void displayToast(MinecraftClient client, ZToast.ZToastType type, Text title, Text description, float z) {
+        ZToast.show(
+                client.getToastManager(),
+                type,
+                title,
+                description,
+                z
+        );
+    }
+
+}

--- a/src/client/resources/tabmanager.client.mixins.json
+++ b/src/client/resources/tabmanager.client.mixins.json
@@ -3,10 +3,12 @@
   "package": "net.snackbag.tabmanager.mixin.client",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "ButtonWidgetMixin",
     "CreativeInventoryScreenMixin",
     "FabricCreativeGuiComponentsMixin",
+    "FabricItemGroupButtonWidgetMixin",
     "ItemGroupButtonWidgetMixin",
-    "FabricCreativeGuiComponentsMixin"
+    "MixinCreativeInventoryScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/assets/tabmanager/lang/de_de.json
+++ b/src/main/resources/assets/tabmanager/lang/de_de.json
@@ -30,5 +30,8 @@
   "tabmanager.gui.edit_screen.filter.use_regex": "Regular Expressions verwenden",
   "tabmanager.gui.edit_screen.filter.add_filter": "Filter hinzufügen...",
   "tabmanager.gui.edit_screen.filter.remove_filter": "Filter entfernen",
-  "tabmanager.gui.edit_screen.filter.edit_filter": "Filter bearbeiten..."
+  "tabmanager.gui.edit_screen.filter.edit_filter": "Filter bearbeiten...",
+
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_title": "Konnte Filter nicht hinzufügen",
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_description": "Ungültiges Prädikat"
 }

--- a/src/main/resources/assets/tabmanager/lang/en_us.json
+++ b/src/main/resources/assets/tabmanager/lang/en_us.json
@@ -30,5 +30,8 @@
   "tabmanager.gui.edit_screen.filter.use_regex": "Use Regular Expressions",
   "tabmanager.gui.edit_screen.filter.add_filter": "Add Filter...",
   "tabmanager.gui.edit_screen.filter.remove_filter": "Remove Filter",
-  "tabmanager.gui.edit_screen.filter.edit_filter": "Edit Filter..."
+  "tabmanager.gui.edit_screen.filter.edit_filter": "Edit Filter...",
+
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_title": "Could not add filter",
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_description": "Invalid predicate"
 }

--- a/src/main/resources/assets/tabmanager/lang/es_es.json
+++ b/src/main/resources/assets/tabmanager/lang/es_es.json
@@ -29,5 +29,8 @@
   "tabmanager.gui.edit_screen.filter.use_regex": "Usar Regular Expressions",
   "tabmanager.gui.edit_screen.filter.add_filter": "Añadir Filtro...",
   "tabmanager.gui.edit_screen.filter.remove_filter": "Sacar Filtro",
-  "tabmanager.gui.edit_screen.filter.edit_filter": "Editar Filtro..."
+  "tabmanager.gui.edit_screen.filter.edit_filter": "Editar Filtro...",
+
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_title": "No se pudo añadir el filtro",
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_description": "Predicado inválido"
 }

--- a/src/main/resources/assets/tabmanager/lang/it_it.json
+++ b/src/main/resources/assets/tabmanager/lang/it_it.json
@@ -29,5 +29,8 @@
   "tabmanager.gui.edit_screen.filter.use_regex": "Usa Regular Expressions",
   "tabmanager.gui.edit_screen.filter.add_filter": "Aggiungere Filtro...",
   "tabmanager.gui.edit_screen.filter.remove_filter": "Rimuovi Filtro",
-  "tabmanager.gui.edit_screen.filter.edit_filter": "Edita Filtro..."
+  "tabmanager.gui.edit_screen.filter.edit_filter": "Edita Filtro...",
+
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_title": "Impossibile aggiungere il filtro",
+  "tabmanager.gui.edit_screen.filter.toast.error.invalid_predicate_description": "Predicato non valido"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
       "net.snackbag.tabmanager.TabManagerClient"
     ]
   },
+  "accessWidener": "tabmanager.classtweaker",
   "mixins": [
     {
       "config": "tabmanager.client.mixins.json",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,6 @@
       "net.snackbag.tabmanager.TabManagerClient"
     ]
   },
-  "accessWidener": "tabmanager.classtweaker",
   "mixins": [
     {
       "config": "tabmanager.client.mixins.json",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,7 @@
     "sources": "https://github.com/snackbag/TabManager",
     "issues": "https://github.com/snackbag/TabManager/issues"
   },
-  "license": "ARR",
+  "license": "LGPL-3.0",
   "icon": "assets/tabmanager/icon.png",
   "environment": "client",
   "entrypoints": {

--- a/src/main/resources/tabmanager.classtweaker
+++ b/src/main/resources/tabmanager.classtweaker
@@ -1,0 +1,1 @@
+classTweaker v1 named

--- a/src/main/resources/tabmanager.classtweaker
+++ b/src/main/resources/tabmanager.classtweaker
@@ -1,1 +1,0 @@
-classTweaker v1 named


### PR DESCRIPTION
This version includes:
- a new license (LGPL-3.0)
- new toast messages if item filter predicate is invalid
- allows the user to move to empty pages in the creative inventory
- fixes config backup file not saving
- add pretty printing to config file
- fix native file dialogs not working on macos
- add own ZToast class to adjust z-index for toasts
- Fixes #1 - Item filters not applying correctly if there are more than one
- Fixes #2 - Predicate field showing messed up predicate
- Fixes #3 - Boundary Checks on page switch
- refactors some code
- added comments to code for better understanding